### PR TITLE
Allow usage on gnome 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "version": 67,
   "gettext-domain" : "gnome-clipboard",


### PR DESCRIPTION
Fixes https://github.com/b00f/gnome-clipboard/issues/22

I tested locally on fedora 37, didn't have any problems.