### PR TITLE
Enable extension on Gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "version": 67,
   "gettext-domain" : "gnome-clipboard",


### PR DESCRIPTION
- Add `shell-version` for Gnome 44.
- Tested on Ubuntu 23.04.

Note that this is merely a naive "upgrade", without proper verification of actual Gnome 44 changes and their implications (if any).

- Tested via local edit, log out/in.
- Based on a few quick tests, I can confirm that clipboard usage works as expected.