### PR TITLE
remove ignoreDeprecations flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ NC = \033[0m # No Color
 TSC := $(shell command -v tsc 2> /dev/null || echo "npx -p typescript tsc")
 
 .PHONY: all build compile pack install enable disable clean update-translations listen test
- 
+
 all: build
 
 build: pack

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,7 +5,6 @@
         "target": "es2022",
         "module": "esnext",
         "moduleResolution": "bundler",
-        "ignoreDeprecations": "6.0",
         "strict": true,
         "outDir": "build",
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This PR removes `ignoreDeprecations` flag as it raise error on node24.

