### PR TITLE
Add: russian translation & fix xgettext deprecated flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ disable:
 	@echo "$(GREEN)Extension disabled!$(NC)"
 
 update-translations:
-	@xgettext -L JavaScript --no-wrap --no-location --sort-output --from-code=UTF-8 -k_ -kN_ -o $(POT_FILE) $(DIST_DIR)/*.js --package-name $(EXT_NAME)
+	@xgettext -L JavaScript --no-wrap --no-location --sort-by-file --from-code=UTF-8 -k_ -kN_ -o $(POT_FILE) $(DIST_DIR)/*.js --package-name $(EXT_NAME)
 	@for f in ./po/*.po ; do \
 		msgmerge --no-location -N $$f $(POT_FILE) -o $$f ;\
 	done

--- a/po/gnome-clipboard.pot
+++ b/po/gnome-clipboard.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-clipboard\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-11 01:41+0800\n"
+"POT-Creation-Date: 2026-06-05 18:44+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,53 +17,107 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "Are you sure you want to remove all items?"
+msgid "Previous Item"
 msgstr ""
 
-msgid "Cancel"
+msgid "Next Item"
 msgstr ""
 
-msgid "Clear history?"
+msgid "Private Mode"
+msgstr ""
+
+msgid "Pin Current Item"
+msgstr ""
+
+msgid "Clear History"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Service"
+msgstr ""
+
+msgid "Clipboard"
 msgstr ""
 
 msgid "Clipboard updated"
 msgstr ""
 
-msgid "Copy time"
+msgid "Clear history?"
+msgstr ""
+
+msgid "Are you sure you want to remove all items?"
 msgstr ""
 
 msgid "Empty"
 msgstr ""
 
-msgid "Enable"
-msgstr ""
-
-msgid "Gnome Clipboard"
-msgstr ""
-
-msgid "Maximum size of history:"
-msgstr ""
-
-msgid "Most usage"
+msgid "Cancel"
 msgstr ""
 
 msgid "OK"
 msgstr ""
 
+msgid "Pinned"
+msgstr ""
+
+msgid "Recent History"
+msgstr ""
+
+msgid "Clipboard is empty"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
-msgid "Recent usage"
+msgid "Maximum size of history:"
 msgstr ""
 
-msgid "Shortcuts"
+msgid "Sort history by:"
 msgstr ""
 
-msgid "This operation cannot be undone."
+msgid "Read clipboard by timer:"
 msgstr ""
 
 msgid "Timer interval (Millisecond):"
 msgstr ""
 
-msgid "Type here to search..."
+msgid "Save only pinned items:"
+msgstr ""
+
+msgid "Show notifications"
+msgstr ""
+
+msgid "Privacy"
+msgstr ""
+
+msgid "Blacklisted App IDs"
+msgstr ""
+
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+msgid "Use formats like <Super>v, <Control><Alt>c, etc."
+msgstr ""
+
+msgid "Toggle History Menu"
+msgstr ""
+
+msgid "Toggle Private Mode"
+msgstr ""
+
+msgid "Select Next Item"
+msgstr ""
+
+msgid "Select Previous Item"
+msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "New shortcut..."
+msgstr ""
+
+msgid "Search clipboard..."
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-clipboard\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-11 01:41+0800\n"
-"PO-Revision-Date: 2026-06-05 18:31+0300\n"
+"POT-Creation-Date: 2026-06-05 18:44+0300\n"
+"PO-Revision-Date: 2026-06-05 18:56+0300\n"
 "Last-Translator: DUB1401 <vlad.milosta@outlook.com>\n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -18,53 +18,128 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-msgid "Are you sure you want to remove all items?"
-msgstr "Вы уверены, что хотите удалить все элементы?"
+msgid "Previous Item"
+msgstr "Предыдущий элемент"
 
-msgid "Cancel"
-msgstr "Отмена"
+msgid "Next Item"
+msgstr "Следующий элемент"
 
-msgid "Clear history?"
-msgstr "Очистить историю?"
+msgid "Private Mode"
+msgstr "Приватный режим"
+
+msgid "Pin Current Item"
+msgstr "Закрепить текущий элемент"
+
+msgid "Clear History"
+msgstr "Очистить историю"
+
+msgid "Settings"
+msgstr "Настройки"
+
+msgid "Service"
+msgstr ""
+
+msgid "Clipboard"
+msgstr "Буфер обмена"
 
 msgid "Clipboard updated"
 msgstr "Буфер обмена обновлён"
 
-msgid "Copy time"
-msgstr "Время копирования"
+msgid "Clear history?"
+msgstr "Очистить историю?"
+
+msgid "Are you sure you want to remove all items?"
+msgstr "Вы уверены, что хотите удалить все элементы?"
 
 msgid "Empty"
 msgstr "Очистить"
 
-msgid "Enable"
-msgstr "Включить"
-
-msgid "Gnome Clipboard"
-msgstr ""
-
-msgid "Maximum size of history:"
-msgstr "Максимальный размер истории:"
-
-msgid "Most usage"
-msgstr "Часто используемые"
+msgid "Cancel"
+msgstr "Отмена"
 
 msgid "OK"
 msgstr "ОК"
 
+msgid "Pinned"
+msgstr "Закреплено"
+
+msgid "Recent History"
+msgstr "Недавние"
+
+msgid "Clipboard is empty"
+msgstr "Буфер обмена пуст"
+
 msgid "Preferences"
-msgstr "Настройки"
+msgstr "Параметры"
 
-msgid "Recent usage"
-msgstr "Недавно использованные"
+msgid "Maximum size of history:"
+msgstr "Максимальный размер истории:"
 
-msgid "Shortcuts"
-msgstr "Сочетания клавиш"
+msgid "Sort history by:"
+msgstr "Сортировать историю по:"
 
-msgid "This operation cannot be undone."
-msgstr "Очищенные данные невозможно восстановить."
+msgid "Read clipboard by timer:"
+msgstr "Считывать буфер обмена по таймеру:"
 
 msgid "Timer interval (Millisecond):"
 msgstr "Интервал (в миллисекундах):"
 
-msgid "Type here to search..."
-msgstr "Введите для поиска..."
+msgid "Save only pinned items:"
+msgstr "Сохранять только закреплённые элементы:"
+
+msgid "Show notifications"
+msgstr "Показывать уведомления"
+
+msgid "Privacy"
+msgstr "Приватность"
+
+msgid "Blacklisted App IDs"
+msgstr "ID приложений чёрного списка"
+
+msgid "Keyboard Shortcuts"
+msgstr "Сочетания клавиш"
+
+msgid "Use formats like <Super>v, <Control><Alt>c, etc."
+msgstr "Используйте формат наподобие <Super>v, <Control><Alt>c, и т.д."
+
+msgid "Toggle History Menu"
+msgstr "Переключить меню истории"
+
+msgid "Toggle Private Mode"
+msgstr "Переключить приватный режим"
+
+msgid "Select Next Item"
+msgstr "Выбрать следующий элемент"
+
+msgid "Select Previous Item"
+msgstr "Выбрать предыдущий элемент"
+
+msgid "None"
+msgstr ""
+
+msgid "New shortcut..."
+msgstr "Новое сочетание клавиш..."
+
+msgid "Search clipboard..."
+msgstr "Поиск..."
+
+#~ msgid "Copy time"
+#~ msgstr "Время копирования"
+
+#~ msgid "Enable"
+#~ msgstr "Включить"
+
+#~ msgid "Most usage"
+#~ msgstr "Часто используемые"
+
+#~ msgid "Recent usage"
+#~ msgstr "Недавно использованные"
+
+#~ msgid "Shortcuts"
+#~ msgstr "Сочетания клавиш"
+
+#~ msgid "This operation cannot be undone."
+#~ msgstr "Очищенные данные невозможно восстановить."
+
+#~ msgid "Type here to search..."
+#~ msgstr "Введите для поиска..."

--- a/po/ru.po
+++ b/po/ru.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the gnome-clipboard package.
 # DUB1401 <vlad.milosta@outlook.com>, 2026.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-clipboard\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -122,24 +122,3 @@ msgstr "Новое сочетание клавиш..."
 
 msgid "Search clipboard..."
 msgstr "Поиск..."
-
-#~ msgid "Copy time"
-#~ msgstr "Время копирования"
-
-#~ msgid "Enable"
-#~ msgstr "Включить"
-
-#~ msgid "Most usage"
-#~ msgstr "Часто используемые"
-
-#~ msgid "Recent usage"
-#~ msgstr "Недавно использованные"
-
-#~ msgid "Shortcuts"
-#~ msgstr "Сочетания клавиш"
-
-#~ msgid "This operation cannot be undone."
-#~ msgstr "Очищенные данные невозможно восстановить."
-
-#~ msgid "Type here to search..."
-#~ msgstr "Введите для поиска..."

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the gnome-clipboard package.
+# DUB1401 <vlad.milosta@outlook.com>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-clipboard\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-11 01:41+0800\n"
+"PO-Revision-Date: 2026-06-05 18:31+0300\n"
+"Last-Translator: DUB1401 <vlad.milosta@outlook.com>\n"
+"Language-Team: \n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
+
+msgid "Are you sure you want to remove all items?"
+msgstr "Вы уверены, что хотите удалить все элементы?"
+
+msgid "Cancel"
+msgstr "Отмена"
+
+msgid "Clear history?"
+msgstr "Очистить историю?"
+
+msgid "Clipboard updated"
+msgstr "Буфер обмена обновлён"
+
+msgid "Copy time"
+msgstr "Время копирования"
+
+msgid "Empty"
+msgstr "Очистить"
+
+msgid "Enable"
+msgstr "Включить"
+
+msgid "Gnome Clipboard"
+msgstr ""
+
+msgid "Maximum size of history:"
+msgstr "Максимальный размер истории:"
+
+msgid "Most usage"
+msgstr "Часто используемые"
+
+msgid "OK"
+msgstr "ОК"
+
+msgid "Preferences"
+msgstr "Настройки"
+
+msgid "Recent usage"
+msgstr "Недавно использованные"
+
+msgid "Shortcuts"
+msgstr "Сочетания клавиш"
+
+msgid "This operation cannot be undone."
+msgstr "Очищенные данные невозможно восстановить."
+
+msgid "Timer interval (Millisecond):"
+msgstr "Интервал (в миллисекундах):"
+
+msgid "Type here to search..."
+msgstr "Введите для поиска..."


### PR DESCRIPTION
Translate to Russian.

When I run `make update-translations` outputs:
```
xgettext: The option '--sort-output' is deprecated.
xgettext: error while opening "dist/*.js" for reading: No such file or directory
make: *** [Makefile:68: update-translations] Error 1
```

I fix it by replace `--sort-output` to `--sort-by-file` flag.