### PR TITLE
perf: don't rebuild the clipboard menu on every copy

### DIFF
--- a/src/clipboardItem.ts
+++ b/src/clipboardItem.ts
@@ -14,6 +14,11 @@ export class ClipboardItem {
     public type: ClipboardItemType;
     public imagePath: string | null;
 
+    // id() hashes the full item text and is called once per item on every menu
+    // rebuild (plus once per probe in lookups). The identity of an item never
+    // changes after construction, so compute it lazily and keep it.
+    private _id: number | null = null;
+
     constructor(text: string, usage: number, pinned: boolean, copiedAt: number, usedAt: number, 
                 type: ClipboardItemType = ClipboardItemType.TEXT, imagePath: string | null = null) {
       this.text = text;
@@ -26,10 +31,12 @@ export class ClipboardItem {
     }
 
     public id(): number {
-      if (this.type === ClipboardItemType.IMAGE && this.imagePath) {
-        return utils.hashCode(this.imagePath);
+      if (this._id === null) {
+        this._id = (this.type === ClipboardItemType.IMAGE && this.imagePath)
+          ? utils.hashCode(this.imagePath)
+          : utils.hashCode(this.text);
       }
-      return utils.hashCode(this.text);
+      return this._id;
     }
 
     public display(): string {

--- a/src/clipboardItem.ts
+++ b/src/clipboardItem.ts
@@ -5,6 +5,18 @@ export enum ClipboardItemType {
     IMAGE
 }
 
+// Store.saveImage() names the file `<id>.png`, where <id> is the hash of the
+// image bytes -- the same value ClipboardPanel tracks as the current selection.
+// Recover it from the filename so an image item's id() matches that selection;
+// hashing the path instead produced an id nothing else in the extension ever
+// computes, so an image was never highlighted and next/prev went dead after
+// copying one.
+function imageID(path: string): number {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  const match = name.match(/^(-?\d+)\.png$/);
+  return match ? Number(match[1]) : utils.hashCode(path);
+}
+
 export class ClipboardItem {
     public text: string;
     public usage: number;
@@ -33,7 +45,7 @@ export class ClipboardItem {
     public id(): number {
       if (this._id === null) {
         this._id = (this.type === ClipboardItemType.IMAGE && this.imagePath)
-          ? utils.hashCode(this.imagePath)
+          ? imageID(this.imagePath)
           : utils.hashCode(this.text);
       }
       return this._id;

--- a/src/clipboardPanel.ts
+++ b/src/clipboardPanel.ts
@@ -132,6 +132,14 @@ class ClipboardPanelInternal extends PanelMenu.Button {
         this._history.setItems(history);
         this._refresh();
     }
+
+    // Neither monitoring mode reports what is already on the clipboard when the
+    // extension starts: `owner-changed` only fires on a change, and the timer
+    // only fires after a full interval, which the user can set as high as 100 s.
+    // Read it once here so the extension starts in sync with the current
+    // selection -- after the stored history has been restored, so that
+    // setItems() cannot discard the entry this adds.
+    this._checkClipboard();
   }
 
   private _setupClipboardMonitoring() {

--- a/src/clipboardPanel.ts
+++ b/src/clipboardPanel.ts
@@ -40,6 +40,7 @@ class ClipboardPanelInternal extends PanelMenu.Button {
   private _openStateChangedID: number = 0;
   private _keyPressEventID: number = 0;
   private _focusTimerID: number = 0;
+  private _menuNeedsRebuild: boolean = true;
 
   constructor(settings: any, _gettext: any, uuid: string, openPrefs: () => void) {
     super(0.0, _("Clipboard"), false);
@@ -98,10 +99,13 @@ class ClipboardPanelInternal extends PanelMenu.Button {
     // Search box: filter items as user types
     this._searchBox.onTextChanged(this._onSearch.bind(this));
 
-    // Auto-focus search box when menu opens
+    // Build the item list on demand, then auto-focus the search box
     this._openStateChangedID = this.menu.connect('open-state-changed',
       (_menu: any, open: boolean) => {
         if (open) {
+          if (this._menuNeedsRebuild) {
+            this._rebuildMenu();
+          }
           if (this._focusTimerID) GLib.source_remove(this._focusTimerID);
           this._focusTimerID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
             this._searchBox.setText('');
@@ -124,7 +128,7 @@ class ClipboardPanelInternal extends PanelMenu.Button {
     let history = await this._store.load();
     if (history && history.length > 0) {
         this._history.setItems(history);
-        this._rebuildMenu();
+        this._refresh();
     }
   }
 
@@ -145,7 +149,7 @@ class ClipboardPanelInternal extends PanelMenu.Button {
         try {
             if (text && text.trim().length > 0) {
                 if (this._addClipboard(text)) {
-                    this._rebuildMenu();
+                    this._refresh();
                     this._saveHistoryDebounced();
                 }
             } else {
@@ -178,7 +182,7 @@ class ClipboardPanelInternal extends PanelMenu.Button {
     if (path) {
         this._selectedID = id;
         this._addToHistory("", 1, false, Date.now(), Date.now(), ClipboardItem.ClipboardItemType.IMAGE, path);
-        this._rebuildMenu();
+        this._refresh();
         this._saveHistoryDebounced();
     }
   }
@@ -218,7 +222,7 @@ class ClipboardPanelInternal extends PanelMenu.Button {
     }
     
     this._selectedID = item.id();
-    this._rebuildMenu();
+    this._refresh();
 
     if (this._settings.showNotifications()) {
       Main.notify(_("Clipboard updated"), item.display());
@@ -250,11 +254,37 @@ class ClipboardPanelInternal extends PanelMenu.Button {
       if (prev) this._copyToClipboard(prev);
   }
 
-  private _rebuildMenu() {
-    this._historyMenu.rebuildMenu(this._history.getSorted(this._settings.historySort()), this._selectedID);
-    this._onSearch();
+  // Called whenever the history changes.
+  //
+  // Rebuilding the popup means destroying and recreating one menu item per
+  // history entry, and every item is a dozen St widgets that each need a full
+  // CSS cascade. With a few hundred entries that is hundreds of milliseconds
+  // of work on the compositor thread -- far too expensive to spend on every
+  // clipboard change for a menu that is usually closed and invisible.
+  //
+  // So only the cheap, always-needed state is updated here; the widgets are
+  // rebuilt lazily the next time the menu is actually opened.
+  private _refresh() {
+    this._history.trim(this._settings.historySize());
+
+    const sorted = this._history.getSorted(this._settings.historySort());
+
+    this._historyMenu.updateNavigation(sorted, this._selectedID);
     this._actionBar.enablePrevButton(this._historyMenu.hasPrevItem());
     this._actionBar.enableNextButton(this._historyMenu.hasNextItem());
+
+    this._menuNeedsRebuild = true;
+    if (this.menu.isOpen) {
+      this._rebuildMenu(sorted);
+    }
+  }
+
+  private _rebuildMenu(sorted?: Array<ClipboardItem.ClipboardItem>) {
+    this._historyMenu.rebuildMenu(
+      sorted ?? this._history.getSorted(this._settings.historySort()),
+      this._selectedID);
+    this._onSearch();
+    this._menuNeedsRebuild = false;
   }
 
   private _onSearch() {
@@ -264,13 +294,13 @@ class ClipboardPanelInternal extends PanelMenu.Button {
 
   private _onPinItem(item: ClipboardItem.ClipboardItem) {
       item.pinned = !item.pinned;
-      this._rebuildMenu();
+      this._refresh();
       this._saveHistoryDebounced();
   }
 
   private _onRemoveItem(item: ClipboardItem.ClipboardItem) {
       this._history.delete(item.id());
-      this._rebuildMenu();
+      this._refresh();
       this._saveHistoryDebounced();
   }
 
@@ -286,7 +316,7 @@ class ClipboardPanelInternal extends PanelMenu.Button {
   private _doClearHistory(){
     this._history.clear();
     this._store.save([]);
-    this._rebuildMenu();
+    this._refresh();
   }
 
   destroy() {

--- a/src/clipboardPanel.ts
+++ b/src/clipboardPanel.ts
@@ -7,6 +7,7 @@ import Gio from 'gi://Gio';
 import St from 'gi://St';
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
+import Meta from 'gi://Meta';
 
 import * as History from './history.js';
 import * as HistoryMenu from './historyMenu.js';
@@ -40,6 +41,7 @@ class ClipboardPanelInternal extends PanelMenu.Button {
   private _openStateChangedID: number = 0;
   private _keyPressEventID: number = 0;
   private _focusTimerID: number = 0;
+  private _selectionOwnerChangedID: number = 0;
   private _menuNeedsRebuild: boolean = true;
 
   constructor(settings: any, _gettext: any, uuid: string, openPrefs: () => void) {
@@ -133,10 +135,32 @@ class ClipboardPanelInternal extends PanelMenu.Button {
   }
 
   private _setupClipboardMonitoring() {
-    this._clipboardTimerID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
-        this._checkClipboard();
-        return GLib.SOURCE_CONTINUE;
-    });
+    // A poll wakes the shell -- and the application that owns the clipboard --
+    // twice a second forever, and re-reads the whole clipboard every tick. When
+    // an image is on the clipboard that means transferring and MD5-hashing the
+    // full PNG on the compositor thread, twice a second, indefinitely.
+    //
+    // The selection-owner signal delivers exactly the same information, only
+    // when something actually changes. The timer is kept for the users who
+    // explicitly opted into it via the `clipboard-timer` setting, which was
+    // otherwise being ignored.
+    if (this._settings.clipboardTimer()) {
+        const interval = this._settings.clipboardTimerIntervalInMillisecond();
+        log.info(`polling clipboard every ${interval} ms`);
+        this._clipboardTimerID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, interval, () => {
+            this._checkClipboard();
+            return GLib.SOURCE_CONTINUE;
+        });
+        return;
+    }
+
+    const selection = global.display.get_selection();
+    this._selectionOwnerChangedID = selection.connect('owner-changed',
+      (_selection: any, selectionType: number) => {
+        if (selectionType === Meta.SelectionType.SELECTION_CLIPBOARD) {
+            this._checkClipboard();
+        }
+      });
   }
 
   private _checkClipboard() {
@@ -332,6 +356,11 @@ class ClipboardPanelInternal extends PanelMenu.Button {
     if (this._keyPressEventID) {
       this._historyMenu.scrollView.disconnect(this._keyPressEventID);
       this._keyPressEventID = 0;
+    }
+
+    if (this._selectionOwnerChangedID) {
+      global.display.get_selection().disconnect(this._selectionOwnerChangedID);
+      this._selectionOwnerChangedID = 0;
     }
 
     super.destroy();

--- a/src/history.ts
+++ b/src/history.ts
@@ -36,9 +36,18 @@ export class History {
   }
 
   public trim(total: number) {
+    if (total <= 0) {
+      return;
+    }
+
+    // getSorted() puts pinned items first, then the most recently copied ones,
+    // so everything from `total` onwards is the oldest overflow.
     let arr = this.getSorted(Settings.HISTORY_SORT_COPY_TIME);
     for (let i = total; i < arr.length; ++i) {
-      let item: any = arr.pop();
+      let item = arr[i];
+      if (item.pinned) {
+        continue;
+      }
       this._history.delete(item.id());
     }
   }

--- a/src/historyMenu.ts
+++ b/src/historyMenu.ts
@@ -38,12 +38,32 @@ export class HistoryMenu
     this._headers = new Map();
   }
 
+  // Keyboard navigation only depends on the sorted history and the current
+  // selection, not on the widgets. Keeping it separate from rebuildMenu() lets
+  // the shortcuts keep working while the popup is closed and unbuilt.
+  public updateNavigation(
+    history: Array<ClipboardItem.ClipboardItem>,
+    selectedID: number) {
+
+    this._nextItem = null;
+    this._prevItem = null;
+
+    const index = history.findIndex(h => h.id() === selectedID);
+    if (index < 0) {
+      return;
+    }
+
+    if (index - 1 >= 0) {
+      this._nextItem = history[index - 1];
+    }
+    if (index + 1 < history.length) {
+      this._prevItem = history[index + 1];
+    }
+  }
+
   public rebuildMenu(
     history: Array<ClipboardItem.ClipboardItem>,
     selectedID: number) {
-    
-    this._nextItem = null;
-    this._prevItem = null;
 
     if (history.length === 0) {
         super.removeAll();
@@ -63,7 +83,7 @@ export class HistoryMenu
     if (pinned.length > 0) {
       this._addHeader(_("Pinned"));
       pinned.forEach((info) => {
-        this._addItem(info, selectedID, history);
+        this._addItem(info, selectedID);
       });
       super.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
     }
@@ -71,7 +91,7 @@ export class HistoryMenu
     if (recent.length > 0) {
       this._addHeader(_("Recent History"));
       recent.forEach((info) => {
-        this._addItem(info, selectedID, history);
+        this._addItem(info, selectedID);
       });
     }
   }
@@ -86,7 +106,7 @@ export class HistoryMenu
       super.addMenuItem(header);
   }
 
-  private _addItem(info: ClipboardItem.ClipboardItem, selectedID: number, history: Array<ClipboardItem.ClipboardItem>) {
+  private _addItem(info: ClipboardItem.ClipboardItem, selectedID: number) {
     let item = new MenuItem.MenuItem(info,
       this.onActivateItem.bind(this),
       this.onPinItem.bind(this),
@@ -96,14 +116,6 @@ export class HistoryMenu
 
     if (info.id() == selectedID) {
       (item as any).add_style_class_name('selected');
-      
-      let index = history.findIndex(h => h.id() === info.id());
-      if (index - 1 >= 0) {
-        this._nextItem = history[index - 1];
-      }
-      if (index + 1 < history.length) {
-        this._prevItem = history[index + 1];
-      }
     } else {
       (item as any).remove_style_class_name('selected');
     }


### PR DESCRIPTION
## Problem

Every copy stalls the shell. On GNOME Shell 50.3 / Wayland with 608 history entries, sampling the shell's own CPU time from `/proc/<pid>/schedstat` over a 1 s window around each copy:

```
idle    0.0, 0.0, 0.0, 3.2 ms
copy    450, 385, 403, 402, 451 ms
```

~400 ms on the compositor thread per copy, and the shell is single-threaded, so it is a visible stutter. A 50 KB copy costs the same as a 30-byte one — the work scales with history size, not payload.

## Cause

`_checkClipboard()` calls `_rebuildMenu()` on every clipboard change. That recreates one `MenuItem` per history entry, and each is ~12 `St` widgets needing a full CSS cascade — roughly 7,500 widgets torn down and rebuilt per copy at 608 entries, while the popup is closed and nothing is visible.

Three things compound it:

- `History.trim()` is never called, so `history-size` has no effect and the history grows unbounded.
- `trim()` pops from the array it is iterating, so it removes only half the overflow — `trim(100)` on 608 items leaves 354.
- `_setupClipboardMonitoring()` polls every 500 ms with a hardcoded interval, ignoring both `clipboard-timer` and `timer-interval`.

## Changes

Six commits, each compiling standalone:

1. **`perf: cache ClipboardItem.id()`** — `id()` hashes the full text and is called at least once per item per rebuild. Identity is fixed at construction, so memoize it.
2. **`fix: History.trim() removed only half the overflow`** — index the array instead of mutating it; skip pinned items so users with more pins than `history-size` don't lose them; `total <= 0` is a no-op instead of a wipe.
3. **`perf: don't rebuild the popup menu while it is closed`** — the main fix. Splits `_refresh()` (trim, sort, navigation, action bar — always, cheap) from `_rebuildMenu()` (widgets — only when the menu is open, or lazily on next `open-state-changed`). Next/prev navigation was computed as a side effect of building widgets, which is why the rebuild couldn't just be skipped; it only depended on the sorted history and selection, so it moves to `HistoryMenu.updateNavigation()`. Also restores `history-size` enforcement.
4. **`perf: use the selection-owner signal instead of polling`** — `owner-changed` instead of the 500 ms poll, with the timer kept for users who enable `clipboard-timer`, at their configured interval. Matters most with an image on the clipboard: `_checkImageClipboard()` runs whenever there is no text, so a copied screenshot had the full PNG transferred and MD5-hashed on the compositor thread twice a second for as long as it stayed there.
5. **`fix: read the clipboard once at startup`** — neither monitoring mode picks up what is already on the clipboard: `owner-changed` only fires on a change, and the timer only after a full interval (up to 100 s). Read it once after the stored history is restored.
6. **`fix: image ids never matched the tracked selection`** — `id()` hashed the image path, but `_selectedID` holds the bytes hash that `Store.saveImage()` names the file after, so an image was never highlighted, next/prev went dead after copying one, and pasting one re-wrote the PNG to disk. Recover the id from the filename.

Commits 3 and 4 are independent — either can be dropped. 5 and 6 are from review feedback; 5 belongs with 4, 6 is a pre-existing bug on a line 1 touches.

## Testing

`make compile` and `tsc --project src --noEmit` clean at every commit in the series. The `trim()` and `id()` changes are pure logic and are covered by headless assertions (script not included since the repo has no test harness — happy to add it).

Not yet exercised in a running shell: the numbers above are from the unpatched code, so the interactive paths (first-open rebuild, pin, remove, search, clear, next/prev) still want a manual pass.

